### PR TITLE
Changes to keep track with l3kernel

### DIFF
--- a/amsmath-testmath.tex
+++ b/amsmath-testmath.tex
@@ -9,7 +9,7 @@ File name: \fn{testmath.tex}}
 \author{American Mathematical Society}
 \date{Version 2.0, 1999/11/15}
 
-\usepackage{amsmath,amsthm}
+\usepackage{amsmath,amsthm,trace}
 \usepackage{unicode-math}
 \setmathfont{Cambria Math}
 

--- a/unicode-math.dtx
+++ b/unicode-math.dtx
@@ -2226,16 +2226,16 @@ luatexbase.add_to_callback("luaotfload.patch_font", set_sscale_dimens, "unicode_
 % input only.
 %    \begin{macrocode}
 \cs_set:Npn \um_set_mathcode:nnnn #1#2#3#4 {
-  \Umathcode \intexpr_eval:n {#1} =
-    \mathchar@type#2 \csname sym#3\endcsname \intexpr_eval:n {#4} \scan_stop:
+  \Umathcode \int_eval:n {#1} =
+    \mathchar@type#2 \csname sym#3\endcsname \int_eval:n {#4} \scan_stop:
 }
 \cs_set:Npn \um_set_mathcode:nnn #1#2#3 {
-  \Umathcode \intexpr_eval:n {#1} =
-    \mathchar@type#2 \csname sym#3\endcsname \intexpr_eval:n {#1} \scan_stop:
+  \Umathcode \int_eval:n {#1} =
+    \mathchar@type#2 \csname sym#3\endcsname \int_eval:n {#1} \scan_stop:
 }
 \cs_set:Npn \um_set_mathchar:NNnn #1#2#3#4 {
   \Umathchardef #1 =
-    \mathchar@type#2 \csname sym#3\endcsname \intexpr_eval:n {#4} \scan_stop:
+    \mathchar@type#2 \csname sym#3\endcsname \int_eval:n {#4} \scan_stop:
 }
 \cs_new:Npn \um_set_delcode:nnn #1#2#3 {
   \Udelcode#2 = \csname sym#1\endcsname #3
@@ -3111,6 +3111,22 @@ luatexbase.add_to_callback("luaotfload.patch_font", set_sscale_dimens, "unicode_
   }
 }
 %    \end{macrocode}
+%    
+% The following code used to be in \pkg{l3keyval}, but is no longer there:
+% at some stage, an official interface will be needed to this idea.
+% (It was not documented as a function available in \pkg{l3keyval}!)
+%    \begin{macrocode}
+\group_begin:
+\char_set_catcode:nn{`\Q}{3}
+\cs_gset:Npn\KV_remove_surrounding_spaces:nw#1#2\q_nil{
+  #1{\KV_remove_surrounding_spaces_auxi:w \exp_not:N#2Q~Q}
+}
+\cs_gset:Npn\KV_remove_surrounding_spaces_auxi:w#1~Q{
+  \KV_remove_surrounding_spaces_auxii:w #1 Q
+}
+\cs_gset:Npn\KV_remove_surrounding_spaces_auxii:w#1Q#2{#1}
+\group_end:
+%    \end{macrocode}
 %
 % \begin{macro}{\um_if_mathalph_decl:nTF}
 % Possible forms of input:\\
@@ -3217,7 +3233,7 @@ luatexbase.add_to_callback("luaotfload.patch_font", set_sscale_dimens, "unicode_
 % \cmd\mathbf\ (\etc) \cmd\mathchar\ remappings.
 %    \begin{macrocode}
       \if@tempswa
-        \clist_put_right:Nx \l_um_char_num_range_clist { \intexpr_eval:n {#1} }
+        \clist_put_right:Nx \l_um_char_num_range_clist { \int_eval:n {#1} }
         #4
       \fi
     \fi


### PR DESCRIPTION
Replace \intexpr_eval:n by \int_eval:n
Include copy of \KV_remove_surrounding_spaces:nw
  (formerly in l3keyval)

These changes bring unicode-math in line with l3kernel SVN2490
