### PR TITLE
typo in warning message

### DIFF
--- a/unicode-math.dtx
+++ b/unicode-math.dtx
@@ -6064,11 +6064,11 @@ end
 }
 \msg_new:nnn { unicode-math } { mathtools-overbracket } {
   Using~ \token_to_str:N \overbracket\ and~
-         \token_to_str:N \underbracke\ from~
+         \token_to_str:N \underbracket\ from~
 	 `mathtools'~ package.\\
   \\
   Use~ \token_to_str:N \Uoverbracket\ and~
-       \token_to_str:N \Uunderbracke\ for~
+       \token_to_str:N \Uunderbracket\ for~
        original~ `unicode-math'~ definition.
 }
 \msg_new:nnn { unicode-math } { mathtools-colon } {


### PR DESCRIPTION
Just noticed a small typo in the `\underbracket` redefinition warning.
