### PR TITLE
Change \setmathfont syntax to match fontspec v2.4

### DIFF
--- a/unicode-math.dtx
+++ b/unicode-math.dtx
@@ -178,7 +178,7 @@ This work is "maintained" by Will Robertson.
 % \unimathsetup{math-style=TeX}
 % \setmathfont{Cambria Math}
 % % OR
-% \setmathfont[math-style=TeX]{Cambria Math}
+% \setmathfont{Cambria Math}[math-style=TeX]
 % \end{Verbatim}
 %
 % A short list of package options is shown in \tabref{pkgopt}.
@@ -223,7 +223,7 @@ This work is "maintained" by Will Robertson.
 % provides the mapping between Unicode
 % maths glyphs and macro names (all 3298 — or however many — of them!). A
 % single command
-% \codeline{\cmd\setmathfont\oarg{font features}\marg{font name}}
+% \codeline{\cmd\setmathfont\marg{font name}\oarg{font features}}
 % implements this for every every symbol and alphabetic variant.
 % That means |x| to $x$, |\xi| to $\xi$, |\leq| to $\leq$, etc., |\mathscr{H}|
 % to $\mathscr{H}$ and so on, all for Unicode glyphs within a single font.
@@ -259,7 +259,7 @@ This work is "maintained" by Will Robertson.
 % (simply due to glyph coverage). The \STIX\ font comes to mind as a
 % possible exception. It will therefore be necessary to delegate specific
 % Unicode ranges of glyphs to separate fonts:
-%   \codeline{\cmd\setmathfont|[range=|\meta{unicode range}|,|\meta{font features}|]|\marg{font name}}
+%   \codeline{\cmd\setmathfont\marg{font name}|[range=|\meta{unicode range}|,|\meta{font features}|]|}
 % where \meta{unicode range} is a comma-separated list of Unicode slots and
 % ranges such as |{"27D0-"27EB,"27FF,"295B-"297F}|. You may also use the macro
 % for accessing the glyph, such as \cs{int}, or whole collection of symbols with
@@ -279,7 +279,7 @@ This work is "maintained" by Will Robertson.
 % And now the trick.
 % If a particular math alphabet is not defined in the font, fall back onto the lower-base plane (i.e., upright) glyphs.
 % Therefore, to use an \ascii-encoded fractur font, for example, write
-% \par{\centering|\setmathfont[range=\mathfrak]{SomeFracturFont}|\par}\noindent
+% \par{\centering|\setmathfont{SomeFracturFont}[range=\mathfrak]|\par}\noindent
 % and because the math plane fractur glyphs will be missing, \pkg{unicode-math} will know to use the \ascii\ ones instead.
 % If necessary this behaviour can be forced with |[range=\mathfrac->\mathup]|.
 %
@@ -312,7 +312,7 @@ This work is "maintained" by Will Robertson.
 % (Not everyone agrees with this typesetting choice, though; be careful.)
 %
 % To select a new maths font in a particular version, use the syntax
-%   \codeline{\cmd\setmathfont|[version=|\meta{version name}|,|\meta{font features}|]|\marg{font name}}
+%   \codeline{\cmd\setmathfont\marg{font name}|[version=|\meta{version name}|,|\meta{font features}|]|}
 % and to switch between maths versions mid-document use the standard \LaTeX\ command
 % \cmd\mathversion\marg{version name}.
 %
@@ -543,12 +543,12 @@ This work is "maintained" by Will Robertson.
 % the caligraphic letters are accessed with the same glyph slots as the
 % script letters but with the first stylistic set feature (|ss01|) applied.
 % \begin{verbatim}
-%   \setmathfont[range={\mathcal,\mathbfcal},StylisticSet=1]{xits-math.otf}
+%   \setmathfont{xits-math.otf}[range={\mathcal,\mathbfcal},StylisticSet=1]
 % \end{verbatim}
 % An example is shown below.
 % \begin{quote}
-% \setmathfont[range=\mathscr]{xits-math.otf}
-% \setmathfont[range=\mathcal,StylisticSet=1]{xits-math.otf}
+% \setmathfont{xits-math.otf}[range=\mathscr]
+% \setmathfont{xits-math.otf}[range=\mathcal,StylisticSet=1]
 % The Script style (\cs{mathscr}) in XITS Math is: $\mathscr{ABCXYZ}$\par
 % The Caligraphic style (\cs{mathcal}) in XITS Math is: $\mathcal{ABCXYZ}$
 % \end{quote}
@@ -1787,10 +1787,11 @@ This work is "maintained" by Will Robertson.
 % I hope to improve the performance somehow.
 %
 % \begin{macro}{\setmathfont}
-% \doarg{font features}
+% \doarg{font features (first optional argument retained for backwards compatibility)}
 % \darg{font name}
+% \doarg{font features}
 %    \begin{macrocode}
-\DeclareDocumentCommand \setmathfont { O{} m } {
+\DeclareDocumentCommand \setmathfont { O{} m O{} } {
   \tl_set:Nn \l_@@_fontname_tl {#2}
   \@@_init:
 %    \end{macrocode}
@@ -1805,7 +1806,7 @@ This work is "maintained" by Will Robertson.
 %    \end{macrocode}
 % Parse options and tell people what's going on:
 %    \begin{macrocode}
-  \keys_set_known:nnN {unicode-math} {#1} \l_@@_unknown_keys_clist
+  \keys_set_known:nnN {unicode-math} {#1,#3} \l_@@_unknown_keys_clist
   \bool_if:NT \l_@@_init_bool { \@@_log:n {default-math-font} }
 %    \end{macrocode}
 % Use \pkg{fontspec} to select a font to use.


### PR DESCRIPTION
Since v2.4, the preferred `fontspec` syntax for `\setmainfont` has the optional font features argument following the mandatory font name argument. Here, `\setmathfont` is changed to follow the same syntax, and the documentation is updated accordingly.