### PR TITLE
Fix \underbar code point

### DIFF
--- a/unicode-math-table.tex
+++ b/unicode-math-table.tex
@@ -48,7 +48,7 @@
 \UnicodeMathSymbol{"00315}{\ocommatopright           }{\mathaccent}{combining comma above right}%
 \UnicodeMathSymbol{"0031A}{\droang                   }{\mathaccent}{left angle above (non-spacing)}%
 \UnicodeMathSymbol{"00330}{\wideutilde               }{\mathbotaccent}{under tilde accent (multiple characters and non-spacing)}%
-\UnicodeMathSymbol{"00331}{\underbar                 }{\mathbotaccent}{combining macron below}%
+\UnicodeMathSymbol{"00332}{\underbar                 }{\mathbotaccent}{combining low line}%
 \UnicodeMathSymbol{"00338}{\not                      }{\mathaccent}{combining long solidus overlay}%
 \UnicodeMathSymbol{"00391}{\upAlpha                  }{\mathalpha}{capital alpha, greek}%
 \UnicodeMathSymbol{"00392}{\upBeta                   }{\mathalpha}{capital beta, greek}%


### PR DESCRIPTION
It should be ‘U+0332 COMBINING LOW LINE’, which seems to be the below
equivalent of ‘U+0305 COMBINING OVERLINE’ that we use for `\overbar`. This
is also the character Cambria and XITS make extensible.