### PR TITLE
fix \{,l,r}{v,V,Vv}ert commands

### DIFF
--- a/unicode-math.dtx
+++ b/unicode-math.dtx
@@ -3851,12 +3851,6 @@ This work is "maintained" by Will Robertson.
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\mathrm}
-%    \begin{macrocode}
-\let\mathfence\mathord
-%    \end{macrocode}
-% \end{macro}
-%
 % \begin{macro}{\digamma}
 % \begin{macro}{\Digamma}
 % I might end up just changing these in the table.


### PR DESCRIPTION
Fixes #306.

The problem is that `\mathfence` is eliminated too soon, before `\@@_set_math_fence:nnnn` is run.

I can't think of a correct place to change `\mathfence` to `\mathord`, since loading a new font and having to rerun the setup code could happen at any time.
Leaving `\mathfence` doesn't seem to have any negative consequences.

Test case:

    \documentclass{article}
    \pagestyle{empty}
    
    \usepackage{IEEEtrantools}
    \usepackage{unicode-math}
    \setmathfont{XITS Math}
    
    \begin{document}
    
    \begin{IEEEeqnarray*}{c}
      |       \quad \left|        \frac12 \right|       \\
      \vert   \quad \left\vert    \frac12 \right\vert   \\
      \lvert  \quad \left\lvert   \frac12 \right\lvert  \\
      \rvert  \quad \left\rvert   \frac12 \right\rvert  \\
      \|      \quad \left\|       \frac12 \right\|      \\
      \Vert   \quad \left\Vert    \frac12 \right\Vert   \\
      \lVert  \quad \left\lVert   \frac12 \right\lVert  \\
      \rVert  \quad \left\rVert   \frac12 \right\rVert  \\
      \Vvert  \quad \left\Vvert   \frac12 \right\Vvert  \\
      \lVvert \quad \left\lVvert  \frac12 \right\lVvert \\
      \rVvert \quad \left\rVvert  \frac12 \right\rVvert \\
    \end{IEEEeqnarray*}
    
    \end{document}