### PR TITLE
Enable LuaTeX cramped style using \directlua

### DIFF
--- a/unicode-math.dtx
+++ b/unicode-math.dtx
@@ -1621,7 +1621,7 @@ This work is "maintained" by Will Robertson.
 %    \begin{macrocode}
 \cs_new_protected_nopar:Nn \@@_new_cramped_style:N
 %<XE>  { \quark_new:N #1 }
-%<LU>  { \cs_new_eq:Nc #1 { luatex \cs_to_str:N #1 } }
+%<LU>  { \directlua { tex.enableprimitives("", {"\cs_to_str:N #1"}) } }
 %    \end{macrocode}
 % \end{macro}
 %


### PR DESCRIPTION
This works whether or not the format has already enabled the primitives with their native names. Looking forward, it's like the format will do this.