### PR TITLE
Use \Uroot not \luatexUroot

### DIFF
--- a/unicode-math-compat.dtx
+++ b/unicode-math-compat.dtx
@@ -217,7 +217,7 @@
       && \int_compare_p:nNn { \leftroot@ } = { \c_zero }
      }
      {
-      \luatexUroot \l_@@_radical_sqrt_tl { #1 } { #2 }
+        \Uroot \l_@@_radical_sqrt_tl { #1 } { #2 }
      }
      {
       \hbox_set:Nn \rootbox
@@ -258,7 +258,7 @@
       \mskip \uproot@ mu
       \c_math_toggle_token
      }
-    \luatexUroot \l_@@_radical_sqrt_tl
+      \Uroot \l_@@_radical_sqrt_tl
      {
       \box_move_up:nn { \box_wd:N \l_tmpa_box }
        {

--- a/unicode-math.dtx
+++ b/unicode-math.dtx
@@ -3446,6 +3446,15 @@ This work is "maintained" by Will Robertson.
 %
 % \subsection{Unicode radicals}
 %
+% Make sure \cs{Uroot} is defined in the case where the \LaTeX{}
+% kernel doesn't make it available with its native name.
+%    \begin{macrocode}
+%<*LU>
+\cs_if_exist:NF \Uroot
+  { \cs_new_eq:NN \Uroot \luatexUroot }
+%</LU>
+%    \end{macrocode}
+%
 %    \begin{macrocode}
 \AtBeginDocument{\@@_redefine_radical:}
 \cs_new:Nn \@@_redefine_radical:
@@ -3497,7 +3506,7 @@ This work is "maintained" by Will Robertson.
 %    \begin{macrocode}
     \cs_set:Npn \root ##1 \of ##2
      {
-      \luatexUroot \l_@@_radical_sqrt_tl { ##1 } { ##2 }
+       \Uroot \l_@@_radical_sqrt_tl { ##1 } { ##2 }
      }
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
Based on upcoming kernel changes, this is the best long-term plan. This is the only other case in unicode-math that needs adjustment (after the merge of the \cramped... change).