### PR TITLE
Add U+1EEF0 and U+1EEF1 math operator

### DIFF
--- a/unicode-math-table.tex
+++ b/unicode-math-table.tex
@@ -2440,3 +2440,5 @@
 \UnicodeMathSymbol{"1D7FD}{\mttseven                 }{\mathord}{mathematical monospace digit 7}%
 \UnicodeMathSymbol{"1D7FE}{\mtteight                 }{\mathord}{mathematical monospace digit 8}%
 \UnicodeMathSymbol{"1D7FF}{\mttnine                  }{\mathord}{mathematical monospace digit 9}%
+\UnicodeMathSymbol{"1EEF0}{\arabicmaj                }{\mathop}{arabic mathematical operator meem with hah with tatweel}%
+\UnicodeMathSymbol{"1EEF1}{\arabichad                }{\mathop}{arabic mathematical operator hah with dal}%


### PR DESCRIPTION
They are Arabic math operators with no previous support in TeX (or AMS
table), so I just invented symbol names for them and tried to make them
long to avoid possible clashes.