### PR TITLE
Add missing subscripts (U+2096 - U+209C)

### DIFF
--- a/unicode-math.dtx
+++ b/unicode-math.dtx
@@ -3598,8 +3598,16 @@ This work is "maintained" by Will Robertson.
 \@@_setup_active_subscript:nn {^^^^2090} {a}
 \@@_setup_active_subscript:nn {^^^^2091} {e}
 \@@_setup_active_subscript:nn {^^^^1d62} {i}
+\@@_setup_active_subscript:nn {^^^^2c7c} {j}
+\@@_setup_active_subscript:nn {^^^^2096} {k}
+\@@_setup_active_subscript:nn {^^^^2097} {l}
+\@@_setup_active_subscript:nn {^^^^2098} {m}
+\@@_setup_active_subscript:nn {^^^^2099} {n}
 \@@_setup_active_subscript:nn {^^^^2092} {o}
+\@@_setup_active_subscript:nn {^^^^209a} {p}
 \@@_setup_active_subscript:nn {^^^^1d63} {r}
+\@@_setup_active_subscript:nn {^^^^209b} {s}
+\@@_setup_active_subscript:nn {^^^^209c} {t}
 \@@_setup_active_subscript:nn {^^^^1d64} {u}
 \@@_setup_active_subscript:nn {^^^^1d65} {v}
 \@@_setup_active_subscript:nn {^^^^2093} {x}


### PR DESCRIPTION
Adds missing subscripts. (I don't know how to test this, so this is completely untested!)

Example tex file:
<pre>
\documentclass{article}
\usepackage{fontspec}
\usepackage{unicode-math}
\setmathfont{xits-math.otf}


\begin{document}
a $xₐ$\\
e $xₑ$\\
h $xₕ$\\
i $xᵢ$\\
j $xⱼ$\\
k $xₖ$\\
l $xₗ$\\
m $xₘ$\\
n $xₙ$\\
o $xₒ$\\
p $xₚ$\\
r $xᵣ$\\
s $xₛ$\\
t $xₜ$\\
u $xᵤ$\\
x $xₓ$\\
\end{document}
</pre>

See also:
https://github.com/khaledhosny/xits-math/issues/42
http://www.unicode.org/charts/PDF/U2070.pdf