### PR TITLE
Fix source order and formatting in symbol list.

### DIFF
--- a/unimath-symbols.ltx
+++ b/unimath-symbols.ltx
@@ -46,8 +46,8 @@
 \defmathfont{cambria}{Cambria Math}{66CCCC}
 \defmathfont{asana}{Asana-Math.otf}{6666CC}
 \defmathfont{pagella}{texgyrepagella-math.otf}{AA6666}
-\defmathfont{euler}{euler.otf}{CC66CC}
 \defmathfont{dejavu}{texgyredejavu-math.otf}{AACC66}
+\defmathfont{euler}{euler.otf}{CC66CC}
 
 \def\INPUT{\input{unicode-math-table.tex}}
 \def\TABLE{%
@@ -163,8 +163,8 @@ Nine fonts are shown: (with approximate symbol counts)
 \item[C] \mathversion{cambria} $\mathup{Cambria\ Math}$ (\ref{count:cambria})
 \item[A] \mathversion{asana} $\mathup{Asana\ Math}$ (\ref{count:asana})
 \item[P] \mathversion{pagella} $\mathup{TeX\ Gyre\ Pagella\ Math}$ (\ref{count:pagella})
+\item[D] \mathversion{dejavu} $\mathup{DejaVu\ Math\ TeX\ Gyre}$ (\ref{count:dejavu})
 \item[E] \mathversion{euler} $\mathup{Neo\ Euler}$ (\ref{count:euler})
-\item[D] \mathversion{dejavu} $\mathup{DejaVu Math TeX Gyre}$ (\ref{count:dejavu})
 \end{itemize}
 Symbols defined in Plain \TeX\ are indicated with {\color[gray]{0.6} \textsuperscript{\sffamily (p)}} after their macro name.
 \LaTeX\ follows Plain \TeX, but defines a handful more, indicated with {\color[gray]{0.6} \textsuperscript{\sffamily (l)}}


### PR DESCRIPTION
The name "DejaVu Math TeX Gyre" was not rendered correctly (it had no spaces).