### PR TITLE
fix typo in doc

### DIFF
--- a/unicode-math-doc.tex
+++ b/unicode-math-doc.tex
@@ -242,7 +242,7 @@ If you do not load an OpenType maths font before |\begin{document}|, Latin Moder
 \clist_map_inline:nn {
   normal, literal, up, bfup, bfit, sfup, sfit, bfsfup, bfsfit, bfsf,
   bb, bbit, scr, bfscr, cal, bfcal, frak, bffrak,
-  up, sf, bf, tt, it,
+  sf, bf, tt, it,
   }{\cs{sym#1}~}
 \ExplSyntaxOff
 \end{quote}

--- a/unicode-math-doc.tex
+++ b/unicode-math-doc.tex
@@ -256,6 +256,40 @@ Many of these are also defined with `familiar' synonyms:
   }{\mbox{\cs{math#1}}~}
 \ExplSyntaxOff
 \end{quote}
+
+\begin{table}[t]\centering
+  \topcaption{\pkg{unicode-math} commands.}
+  \tablabel{symvsmath}
+  \begin{tabular}{lll}
+    \toprule
+    \pkg{unicode-math} command & Synonym \\
+    \midrule
+    |\symnormal|  & |\mathnormal| \\
+    |\symliteral| &               \\
+    |\symup|      &               \\
+    |\symbfup|    & |\mathbfup|   \\
+    |\symbfit|    & |\mathbfit|   \\
+    |\symsfup|    & |\mathsfup|   \\
+    |\symsfit|    & |\mathsfit|   \\
+    |\symbfsfup|  & |\mathbfsfup| \\
+    |\symbfsfit|  & |\mathbfsfit| \\
+    |\symbfsf|    & |\mathbfsf|   \\
+    |\symbb|      & |\mathbb|     \\
+    |\symbbit|    & |\mathbbit|   \\
+    |\symscr|     & |\mathscr|    \\
+    |\symbfscr|   & |\mathbfscr|  \\
+    |\symcal|     & |\mathcal|    \\
+    |\symbfcal|   & |\mathbfcal|  \\
+    |\symfrak|    & |\mathfrak|   \\
+    |\symbffrak|  & |\mathbffrak| \\
+    |\symsf|      & |\mathsf|     \\
+    |\symbf|      & |\mathbf|     \\
+    |\symtt|      & |\mathtt|     \\
+    |\symit|      & |\mathit|     \\
+    \bottomrule
+  \end{tabular}
+\end{table}
+
 So what about \cs{mathup}, \cs{mathit}, \cs{mathbf}, \cs{mathsf}, and \cs{mathtt}?
 (N.B.: \cs{mathrm} is defined as a synonym for \cs{mathup}, but the latter is prefered as it is a script-agnostic term.)
 These commands have `overloaded' meanings in \LaTeX, and it's important to consider the subtle differences between, e.g., \cs{symbf} and \cs{mathbf}.

--- a/unicode-math-doc.tex
+++ b/unicode-math-doc.tex
@@ -251,7 +251,8 @@ Many of these are also defined with `familiar' synonyms:
 \ExplSyntaxOn
 \clist_map_inline:nn {
    normal, bb, bbit, scr, bfscr, cal, bfcal, frak, bffrak,
-   bfup, bfit, sfup, sfit, bfsfup, bfsfit, bfsf
+   bfup, bfit, sfup, sfit, bfsfup, bfsfit, bfsf,
+   sf, bf, tt, it,
   }{\mbox{\cs{math#1}}~}
 \ExplSyntaxOff
 \end{quote}


### PR DESCRIPTION
`\symup` appears twice