### PR TITLE
Rename deprecated expl3 command

### DIFF
--- a/um-code-amsmath.dtx
+++ b/um-code-amsmath.dtx
@@ -195,7 +195,7 @@
         { \box_use:N \rootbox }
       \@@_mathstyle_scale:NnnN #1 { \kern } { \fontdimen 64 \g_@@_sqrt_font_cmd_tl } \g_@@_sqrt_font_cmd_tl
       \mkern \leftroot@ mu
-      \box_use_clear:N \l_tmpa_box
+      \box_use_drop:N \l_tmpa_box
     }
 %</XE>
   }

--- a/um-code-compat.dtx
+++ b/um-code-compat.dtx
@@ -124,7 +124,7 @@
          {
            \box_ht:N \l_tmpa_box - \@@_radical_vgap:N #1
          }
-       \box_use_clear:N \l_tmpa_box
+       \box_use_drop:N \l_tmpa_box
      }
   }
 %</XE>

--- a/um-code-epilogue.dtx
+++ b/um-code-epilogue.dtx
@@ -74,7 +74,7 @@
           }
           { \box_use:N \rootbox }
         \@@_mathstyle_scale:NnnN ##1 { \kern } { \fontdimen 64 \g_@@_sqrt_font_cmd_tl } \g_@@_sqrt_font_cmd_tl
-        \box_use_clear:N \l_tmpa_box
+        \box_use_drop:N \l_tmpa_box
       }
   }
 %</XE>


### PR DESCRIPTION
## Status
READY

## Description
Avoid deprecation warnings.

## Todos
- [ ] Tests added to cover new/fixed functionality : *not applicable?*
- [ ] Documentation if necessary : *not applicable*
- [X] Code follows expl3 style guidelines

## Minimal example demonstrating the new/fixed functionality
The following now works.
```
\documentclass{article}
\usepackage[enable-debug]{expl3}
\ExplSyntaxOn \debug_on:n { deprecation } \ExplSyntaxOff
\usepackage{unicode-math}
\begin{document}
\[
  a = b
\]
\end{document}
```

