### PR TITLE
enable syntax highlighting on GitHub [ci skip]

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,25 +19,28 @@ There are two important key points for submitting an issue:
   I don't yet have or can't access.
 
 For example, this is a good minimal example:
-
-    \documentclass{article}
-    \usepackage{unicode-math}
-    \setmathfont{texgyrepagella-math.otf}
-    \begin{document}
-    \[
-      x^2 + y^2 = z^2
-    \]
-    \end{document}
+```tex
+\documentclass{article}
+\usepackage{unicode-math}
+\setmathfont{texgyrepagella-math.otf}
+\begin{document}
+\[
+  x^2 + y^2 = z^2
+\]
+\end{document}
+```
 
 This is an example of a *bad* example:
 
-    \usepackage{unicode-math}
-    \setmathfont{TeX Gyre Pagella Math}
+```tex
+\usepackage{unicode-math}
+\setmathfont{TeX Gyre Pagella Math}
 
-    % later:
-    \[
-      x^2 + y^2 = z^2
-    \]
+% later:
+\[
+  x^2 + y^2 = z^2
+\]
+```
 
 
 ## Branches and Pull Requests

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,7 +8,7 @@ A sentence or two describing the issue.
 - [ ] Links to <tex.stackexchange.com> discussion if appropriate
 
 ## Minimal example demonstrating the issue
-```
+```tex
 \documentclass{article}
 \usepackage{unicode-math}
 \setmathfont{texgyrepagella-math.otf}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ A few sentences describing the overall goals of the pull request's commits.
 - [ ] Code follows expl3 style guidelines
 
 ## Minimal example demonstrating the new/fixed functionality
-```
+```tex
 \documentclass{article}
 \usepackage{unicode-math}
 \begin{document}

--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ PACKAGE USAGE
 
 Please see the PDF documentation for full details. A simple beginning is:
 
-    \usepackage{unicode-math}
-    \setmathfont{texgyrepagella-math.otf}
+```tex
+\usepackage{unicode-math}
+\setmathfont{texgyrepagella-math.otf}
+```
 
 Most LaTeX math should still work after this. (Let me know if it doesn't.)
 Furthermore, it will be in a different font.


### PR DESCRIPTION
## Status
**READY/UNDER DEVELOPMENT/FOR DISCUSSION**

## Description
https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting

## Todos
- [ ] Tests added to cover new/fixed functionality
- [ ] Documentation if necessary
- [ ] Code follows expl3 style guidelines

## Minimal example demonstrating the new/fixed functionality
