### PR TITLE
Fix date in unimath-symbols.pdf

### DIFF
--- a/um-doc-style.tex
+++ b/um-doc-style.tex
@@ -2,9 +2,6 @@
 
 \makeatletter
 \input{unicode-math.dtx}
-\GetFileInfo{unicode-math.dtx}
-\let\umfiledate\filedate
-\let\umfileversion\fileversion
 
 \CheckSum{0}
 \EnableCrossrefs

--- a/unimath-symbols.ltx
+++ b/unimath-symbols.ltx
@@ -150,25 +150,11 @@
 \def\AMSSYMB{\boxdot\boxplus\boxtimes\square\blacksquare\centerdot\lozenge\blacklozenge\circlearrowright\circlearrowleft\leftrightharpoons\boxminus\Vdash\Vvdash\vDash\twoheadrightarrow\twoheadleftarrow\leftleftarrows\rightrightarrows\upuparrows\downdownarrows\upharpoonright\restriction\downharpoonright\upharpoonleft\downharpoonleft\rightarrowtail\leftarrowtail\leftrightarrows\rightleftarrows\Lsh\Rsh\rightsquigarrow\leftrightsquigarrow\looparrowleft\looparrowright\circeq\succsim\gtrsim\gtrapprox\multimap\therefore\because\doteqdot\Doteq\triangleq\precsim\lesssim\lessapprox\eqslantless\eqslantgtr\curlyeqprec\curlyeqsucc\preccurlyeq\leqq\leqslant\lessgtr\backprime\risingdotseq\fallingdotseq\succcurlyeq\geqq\geqslant\gtrless\vartriangleright\vartriangleleft\trianglerighteq\trianglelefteq\bigstar\between\blacktriangledown\blacktriangleright\blacktriangleleft\vartriangle\blacktriangle\triangledown\eqcirc\lesseqgtr\gtreqless\lesseqqgtr\gtreqqless\Rrightarrow\Lleftarrow\veebar\barwedge\doublebarwedge\measuredangle\sphericalangle\varpropto\smallsmile\smallfrown\Subset\Supset\Cup\doublecup\Cap\doublecap\curlywedge\curlyvee\leftthreetimes\rightthreetimes\subseteqq\supseteqq\bumpeq\Bumpeq\lll\llless\ggg\gggtr\circledS\pitchfork\dotplus\backsim\backsimeq\complement\intercal\circledcirc\circledast\circleddash\lvertneqq\gvertneqq\nleq\ngeq\nless\ngtr\nprec\nsucc\lneqq\gneqq\nleqslant\ngeqslant\lneq\gneq\npreceq\nsucceq\precnsim\succnsim\lnsim\gnsim\nleqq\ngeqq\precneqq\succneqq\precnapprox\succnapprox\lnapprox\gnapprox\nsim\ncong\diagup\diagdown\varsubsetneq\varsupsetneq\nsubseteqq\nsupseteqq\subsetneqq\supsetneqq\varsubsetneqq\varsupsetneqq\subsetneq\supsetneq\nsubseteq\nsupseteq\nparallel\nmid\nshortmid\nshortparallel\nvdash\nVdash\nvDash\nVDash\ntrianglerighteq\ntrianglelefteq\ntriangleleft\ntriangleright\nleftarrow\nrightarrow\nLeftarrow\nRightarrow\nLeftrightarrow\nleftrightarrow\divideontimes\varnothing\nexists\Finv\Game\eth\eqsim\beth\gimel\daleth\lessdot\gtrdot\ltimes\rtimes\shortmid\shortparallel\smallsetminus\thicksim\thickapprox\approxeq\succapprox\precapprox\curvearrowleft\curvearrowright\digamma\varkappa\Bbbk\hslash\backepsilon}
 
 \input{unicode-math.dtx}
-\makeatletter
-\def\GetFileInfo#1{%
-  \def\filename{#1}%
-  \def\@tempb##1 ##2 ##3\relax##4\relax{%
-    \def\filedate{##1}%
-    \def\fileversion{##2}%
-    \def\fileinfo{##3}}%
-  \edef\@tempa{\csname ver@#1\endcsname}%
-  \expandafter\@tempb\@tempa\relax? ? \relax\relax}
-\makeatother
-\GetFileInfo{unicode-math.dtx}
-\let\umfiledate\filedate
-\let\umfileversion\fileversion
 
 \begin{document}
 \MakeShortVerb\|
 \title{Every symbol (most symbols) defined by \textsf{unicode-math}}
 \author{Will Robertson}
-\date{\umfiledate \qquad \umfileversion}
 \maketitle
 
 This document uses the file \texttt{unicode-math-table.tex}


### PR DESCRIPTION
## Status
**READY/UNDER DEVELOPMENT/FOR DISCUSSION**

## Description
`\GetFileInfo` does not work, so `\umfiledate` and `\umfileversion` are not resolved (`? ?`) in unimath-symbols.pdf ([CTAN link](http://mirrors.ctan.org/macros/latex/contrib/unicode-math/unimath-symbols.pdf)).
In this PR I remove `\GetFileInfo` and use date as defined in https://github.com/wspr/unicode-math/blob/1dae0d160438ec7d3cd5487af341348e8ff42bac/unicode-math.dtx#L69-L73

## Todos
- [ ] Tests added to cover new/fixed functionality
- [ ] Documentation if necessary
- [ ] Code follows expl3 style guidelines

## Minimal example demonstrating the new/fixed functionality
