### PR TITLE
a few additional subscripts, greek letters

### DIFF
--- a/um-code-sscript.dtx
+++ b/um-code-sscript.dtx
@@ -110,6 +110,11 @@
 \@@_setup_active_superscript:nn {"00B9} {1}
 \@@_setup_active_superscript:nn {"00B2} {2}
 \@@_setup_active_superscript:nn {"00B3} {3}
+\@@_setup_active_superscript:nn {"01D5D}{\beta}
+\@@_setup_active_superscript:nn {"01D5E}{\gamma}
+\@@_setup_active_superscript:nn {"01D5F}{\delta}
+\@@_setup_active_superscript:nn {"01D60}{\phi}
+\@@_setup_active_superscript:nn {"01D61}{\chi}
 \@@_setup_active_superscript:nn {"2074} {4}
 \@@_setup_active_superscript:nn {"2075} {5}
 \@@_setup_active_superscript:nn {"2076} {6}


### PR DESCRIPTION
## Status
Extremely minor.

## Description
Just added a few superscripts for greek letters.


## Minimal example demonstrating the new/fixed functionality
```tex
\documentclass{article}
\usepackage{unicode-math}
\begin{document}
\[
   aᵝ,aᵞ,aᵟ,aᵠ, bᵡ
\]
\end{document}
```

