### PR TITLE
remove spaces in unicode-math-table.tex

### DIFF
--- a/unicode-math-table.tex
+++ b/unicode-math-table.tex
@@ -89,7 +89,7 @@
 \UnicodeMathSymbol{"003B2}{\mupbeta                  }{\mathalpha}{small beta, greek}%
 \UnicodeMathSymbol{"003B3}{\mupgamma                 }{\mathalpha}{small gamma, greek}%
 \UnicodeMathSymbol{"003B4}{\mupdelta                 }{\mathalpha}{small delta, greek}%
-\UnicodeMathSymbol{"003B5}{\mupvarepsilon            }{\mathalpha}{rounded small varepsilon    , greek}%
+\UnicodeMathSymbol{"003B5}{\mupvarepsilon            }{\mathalpha}{rounded small varepsilon, greek}%
 \UnicodeMathSymbol{"003B6}{\mupzeta                  }{\mathalpha}{small zeta, greek}%
 \UnicodeMathSymbol{"003B7}{\mupeta                   }{\mathalpha}{small eta, greek}%
 \UnicodeMathSymbol{"003B8}{\muptheta                 }{\mathalpha}{straight theta, small theta, greek}%
@@ -686,7 +686,7 @@
 \UnicodeMathSymbol{"025AF}{\vrectangle               }{\mathord}{rectangle, white (vertical)}%
 \UnicodeMathSymbol{"025B0}{\parallelogramblack       }{\mathord}{black parallelogram}%
 \UnicodeMathSymbol{"025B1}{\parallelogram            }{\mathord}{parallelogram, open}%
-\UnicodeMathSymbol{"025B2}{\bigblacktriangleup       }{\mathord}{   0x25b2 6 6d      black up-pointing triangle}%
+\UnicodeMathSymbol{"025B2}{\bigblacktriangleup       }{\mathord}{black up-pointing triangle}%
 \UnicodeMathSymbol{"025B3}{\bigtriangleup            }{\mathbin}{big up triangle, open}%
 \UnicodeMathSymbol{"025B4}{\blacktriangle            }{\mathord}{up triangle, filled}%
 \UnicodeMathSymbol{"025B5}{\vartriangle              }{\mathrel}{/triangle - up triangle, open}%
@@ -2133,7 +2133,7 @@
 \UnicodeMathSymbol{"1D6C3}{\mbfbeta                  }{\mathalpha}{mathematical bold small beta}%
 \UnicodeMathSymbol{"1D6C4}{\mbfgamma                 }{\mathalpha}{mathematical bold small gamma}%
 \UnicodeMathSymbol{"1D6C5}{\mbfdelta                 }{\mathalpha}{mathematical bold small delta}%
-\UnicodeMathSymbol{"1D6C6}{\mbfvarepsilon            }{\mathalpha}{mathematical bold small varepsilon    }%
+\UnicodeMathSymbol{"1D6C6}{\mbfvarepsilon            }{\mathalpha}{mathematical bold small varepsilon}%
 \UnicodeMathSymbol{"1D6C7}{\mbfzeta                  }{\mathalpha}{mathematical bold small zeta}%
 \UnicodeMathSymbol{"1D6C8}{\mbfeta                   }{\mathalpha}{mathematical bold small eta}%
 \UnicodeMathSymbol{"1D6C9}{\mbftheta                 }{\mathalpha}{mathematical bold small theta}%
@@ -2155,7 +2155,7 @@
 \UnicodeMathSymbol{"1D6D9}{\mbfpsi                   }{\mathalpha}{mathematical bold small psi}%
 \UnicodeMathSymbol{"1D6DA}{\mbfomega                 }{\mathalpha}{mathematical bold small omega}%
 \UnicodeMathSymbol{"1D6DB}{\mbfpartial               }{\mathalpha}{mathematical bold partial differential}%
-\UnicodeMathSymbol{"1D6DC}{\mbfepsilon               }{\mathalpha}{mathematical bold varepsilon     symbol}%
+\UnicodeMathSymbol{"1D6DC}{\mbfepsilon               }{\mathalpha}{mathematical bold varepsilon symbol}%
 \UnicodeMathSymbol{"1D6DD}{\mbfvartheta              }{\mathalpha}{mathematical bold theta symbol}%
 \UnicodeMathSymbol{"1D6DE}{\mbfvarkappa              }{\mathalpha}{mathematical bold kappa symbol}%
 \UnicodeMathSymbol{"1D6DF}{\mbfphi                   }{\mathalpha}{mathematical bold phi symbol}%
@@ -2191,7 +2191,7 @@
 \UnicodeMathSymbol{"1D6FD}{\mitbeta                  }{\mathalpha}{mathematical italic small beta}%
 \UnicodeMathSymbol{"1D6FE}{\mitgamma                 }{\mathalpha}{mathematical italic small gamma}%
 \UnicodeMathSymbol{"1D6FF}{\mitdelta                 }{\mathalpha}{mathematical italic small delta}%
-\UnicodeMathSymbol{"1D700}{\mitvarepsilon            }{\mathalpha}{mathematical italic small varepsilon    }%
+\UnicodeMathSymbol{"1D700}{\mitvarepsilon            }{\mathalpha}{mathematical italic small varepsilon}%
 \UnicodeMathSymbol{"1D701}{\mitzeta                  }{\mathalpha}{mathematical italic small zeta}%
 \UnicodeMathSymbol{"1D702}{\miteta                   }{\mathalpha}{mathematical italic small eta}%
 \UnicodeMathSymbol{"1D703}{\mittheta                 }{\mathalpha}{mathematical italic small theta}%
@@ -2213,7 +2213,7 @@
 \UnicodeMathSymbol{"1D713}{\mitpsi                   }{\mathalpha}{mathematical italic small psi}%
 \UnicodeMathSymbol{"1D714}{\mitomega                 }{\mathalpha}{mathematical italic small omega}%
 \UnicodeMathSymbol{"1D715}{\mitpartial               }{\mathalpha}{mathematical italic partial differential}%
-\UnicodeMathSymbol{"1D716}{\mitepsilon               }{\mathalpha}{mathematical italic varepsilon     symbol}%
+\UnicodeMathSymbol{"1D716}{\mitepsilon               }{\mathalpha}{mathematical italic varepsilon symbol}%
 \UnicodeMathSymbol{"1D717}{\mitvartheta              }{\mathalpha}{mathematical italic theta symbol}%
 \UnicodeMathSymbol{"1D718}{\mitvarkappa              }{\mathalpha}{mathematical italic kappa symbol}%
 \UnicodeMathSymbol{"1D719}{\mitphi                   }{\mathalpha}{mathematical italic phi symbol}%
@@ -2249,7 +2249,7 @@
 \UnicodeMathSymbol{"1D737}{\mbfitbeta                }{\mathalpha}{mathematical bold italic small beta}%
 \UnicodeMathSymbol{"1D738}{\mbfitgamma               }{\mathalpha}{mathematical bold italic small gamma}%
 \UnicodeMathSymbol{"1D739}{\mbfitdelta               }{\mathalpha}{mathematical bold italic small delta}%
-\UnicodeMathSymbol{"1D73A}{\mbfitvarepsilon          }{\mathalpha}{mathematical bold italic small varepsilon    }%
+\UnicodeMathSymbol{"1D73A}{\mbfitvarepsilon          }{\mathalpha}{mathematical bold italic small varepsilon}%
 \UnicodeMathSymbol{"1D73B}{\mbfitzeta                }{\mathalpha}{mathematical bold italic small zeta}%
 \UnicodeMathSymbol{"1D73C}{\mbfiteta                 }{\mathalpha}{mathematical bold italic small eta}%
 \UnicodeMathSymbol{"1D73D}{\mbfittheta               }{\mathalpha}{mathematical bold italic small theta}%
@@ -2271,7 +2271,7 @@
 \UnicodeMathSymbol{"1D74D}{\mbfitpsi                 }{\mathalpha}{mathematical bold italic small psi}%
 \UnicodeMathSymbol{"1D74E}{\mbfitomega               }{\mathalpha}{mathematical bold italic small omega}%
 \UnicodeMathSymbol{"1D74F}{\mbfitpartial             }{\mathalpha}{mathematical bold italic partial differential}%
-\UnicodeMathSymbol{"1D750}{\mbfitepsilon             }{\mathalpha}{mathematical bold italic varepsilon     symbol}%
+\UnicodeMathSymbol{"1D750}{\mbfitepsilon             }{\mathalpha}{mathematical bold italic varepsilon symbol}%
 \UnicodeMathSymbol{"1D751}{\mbfitvartheta            }{\mathalpha}{mathematical bold italic theta symbol}%
 \UnicodeMathSymbol{"1D752}{\mbfitvarkappa            }{\mathalpha}{mathematical bold italic kappa symbol}%
 \UnicodeMathSymbol{"1D753}{\mbfitphi                 }{\mathalpha}{mathematical bold italic phi symbol}%
@@ -2307,7 +2307,7 @@
 \UnicodeMathSymbol{"1D771}{\mbfsansbeta              }{\mathalpha}{mathematical sans-serif bold small beta}%
 \UnicodeMathSymbol{"1D772}{\mbfsansgamma             }{\mathalpha}{mathematical sans-serif bold small gamma}%
 \UnicodeMathSymbol{"1D773}{\mbfsansdelta             }{\mathalpha}{mathematical sans-serif bold small delta}%
-\UnicodeMathSymbol{"1D774}{\mbfsansvarepsilon        }{\mathalpha}{mathematical sans-serif bold small varepsilon    }%
+\UnicodeMathSymbol{"1D774}{\mbfsansvarepsilon        }{\mathalpha}{mathematical sans-serif bold small varepsilon}%
 \UnicodeMathSymbol{"1D775}{\mbfsanszeta              }{\mathalpha}{mathematical sans-serif bold small zeta}%
 \UnicodeMathSymbol{"1D776}{\mbfsanseta               }{\mathalpha}{mathematical sans-serif bold small eta}%
 \UnicodeMathSymbol{"1D777}{\mbfsanstheta             }{\mathalpha}{mathematical sans-serif bold small theta}%
@@ -2329,7 +2329,7 @@
 \UnicodeMathSymbol{"1D787}{\mbfsanspsi               }{\mathalpha}{mathematical sans-serif bold small psi}%
 \UnicodeMathSymbol{"1D788}{\mbfsansomega             }{\mathalpha}{mathematical sans-serif bold small omega}%
 \UnicodeMathSymbol{"1D789}{\mbfsanspartial           }{\mathalpha}{mathematical sans-serif bold partial differential}%
-\UnicodeMathSymbol{"1D78A}{\mbfsansepsilon           }{\mathalpha}{mathematical sans-serif bold varepsilon     symbol}%
+\UnicodeMathSymbol{"1D78A}{\mbfsansepsilon           }{\mathalpha}{mathematical sans-serif bold varepsilon symbol}%
 \UnicodeMathSymbol{"1D78B}{\mbfsansvartheta          }{\mathalpha}{mathematical sans-serif bold theta symbol}%
 \UnicodeMathSymbol{"1D78C}{\mbfsansvarkappa          }{\mathalpha}{mathematical sans-serif bold kappa symbol}%
 \UnicodeMathSymbol{"1D78D}{\mbfsansphi               }{\mathalpha}{mathematical sans-serif bold phi symbol}%
@@ -2365,7 +2365,7 @@
 \UnicodeMathSymbol{"1D7AB}{\mbfitsansbeta            }{\mathalpha}{mathematical sans-serif bold italic small beta}%
 \UnicodeMathSymbol{"1D7AC}{\mbfitsansgamma           }{\mathalpha}{mathematical sans-serif bold italic small gamma}%
 \UnicodeMathSymbol{"1D7AD}{\mbfitsansdelta           }{\mathalpha}{mathematical sans-serif bold italic small delta}%
-\UnicodeMathSymbol{"1D7AE}{\mbfitsansvarepsilon      }{\mathalpha}{mathematical sans-serif bold italic small varepsilon    }%
+\UnicodeMathSymbol{"1D7AE}{\mbfitsansvarepsilon      }{\mathalpha}{mathematical sans-serif bold italic small varepsilon}%
 \UnicodeMathSymbol{"1D7AF}{\mbfitsanszeta            }{\mathalpha}{mathematical sans-serif bold italic small zeta}%
 \UnicodeMathSymbol{"1D7B0}{\mbfitsanseta             }{\mathalpha}{mathematical sans-serif bold italic small eta}%
 \UnicodeMathSymbol{"1D7B1}{\mbfitsanstheta           }{\mathalpha}{mathematical sans-serif bold italic small theta}%
@@ -2387,7 +2387,7 @@
 \UnicodeMathSymbol{"1D7C1}{\mbfitsanspsi             }{\mathalpha}{mathematical sans-serif bold italic small psi}%
 \UnicodeMathSymbol{"1D7C2}{\mbfitsansomega           }{\mathalpha}{mathematical sans-serif bold italic small omega}%
 \UnicodeMathSymbol{"1D7C3}{\mbfitsanspartial         }{\mathalpha}{mathematical sans-serif bold italic partial differential}%
-\UnicodeMathSymbol{"1D7C4}{\mbfitsansepsilon         }{\mathalpha}{mathematical sans-serif bold italic varepsilon     symbol}%
+\UnicodeMathSymbol{"1D7C4}{\mbfitsansepsilon         }{\mathalpha}{mathematical sans-serif bold italic varepsilon symbol}%
 \UnicodeMathSymbol{"1D7C5}{\mbfitsansvartheta        }{\mathalpha}{mathematical sans-serif bold italic theta symbol}%
 \UnicodeMathSymbol{"1D7C6}{\mbfitsansvarkappa        }{\mathalpha}{mathematical sans-serif bold italic kappa symbol}%
 \UnicodeMathSymbol{"1D7C7}{\mbfitsansphi             }{\mathalpha}{mathematical sans-serif bold italic phi symbol}%


### PR DESCRIPTION
## Status
**READY/UNDER DEVELOPMENT/FOR DISCUSSION**

## Description

Simply remove some spaces in `unicode-math-table.tex`.

Some questions:

- Why there are something like `b:`, `p:`, `/neg /lnot`? It seems unnecessary and confusing.
- In Unicode 11.0, some math related symbols have been added into the [Miscellaneous Symbols and Arrows](https://www.unicode.org/charts/PDF/Unicode-11.0/U110-2B00.pdf) block. Do you have plan to add them into `unicode-math-table.`?