### PR TITLE
[doc] add missing `literal` candidate for `math-style`

### DIFF
--- a/um-doc-main.tex
+++ b/um-doc-main.tex
@@ -500,8 +500,8 @@ upper- and lowercase Greek, but italic lowercase latin. Finally, it is not unkno
 for all characters, as seen in the Euler fonts.
 
 The \pkg{unicode-math} package accommodates these possibilities with the
-option \opt{math-style} that takes one of four (case sensitive) arguments:
-\opt{TeX}, \opt{ISO}, \opt{french}, or \opt{upright}.\footnote{Interface inspired by Walter Schmidt's \pkg{lucimatx} package.}
+option \opt{math-style} that takes one of five (case sensitive) arguments:
+\opt{TeX}, \opt{ISO}, \opt{french}, \opt{upright}, or \opt{literal}.\footnote{Interface inspired by Walter Schmidt's \pkg{lucimatx} package.}
 The \opt{math-style} options' effects are shown in brief in \tabref{math-style}.
 
 The philosophy behind the interface to the mathematical symbols


### PR DESCRIPTION
## Status
**READY**

## Description
§5.1 misses `math-style=literal`.