### PR TITLE
Remap characters for \setminus and \smallsetminus

### DIFF
--- a/unicode-math-table.tex
+++ b/unicode-math-table.tex
@@ -344,7 +344,7 @@
 \UnicodeMathSymbol{"02213}{\mp                       }{\mathbin}{minus-or-plus sign}%
 \UnicodeMathSymbol{"02214}{\dotplus                  }{\mathbin}{plus sign, dot above}%
 \UnicodeMathSymbol{"02215}{\divslash                 }{\mathbin}{division slash}%
-\UnicodeMathSymbol{"02216}{\smallsetminus            }{\mathbin}{small set minus (cf. reverse solidus)}%
+\UnicodeMathSymbol{"029F5}{\smallsetminus            }{\mathbin}{small set minus (cf. reverse solidus)}%
 \UnicodeMathSymbol{"02217}{\ast                      }{\mathbin}{centered asterisk}%
 \UnicodeMathSymbol{"02218}{\vysmwhtcircle            }{\mathbin}{composite function (small circle)}%
 \UnicodeMathSymbol{"02219}{\vysmblkcircle            }{\mathbin}{bullet operator}%
@@ -1116,7 +1116,7 @@
 \UnicodeMathSymbol{"029F2}{\errbarcircle             }{\mathord}{error-barred white circle}%
 \UnicodeMathSymbol{"029F3}{\errbarblackcircle        }{\mathord}{error-barred black circle}%
 \UnicodeMathSymbol{"029F4}{\ruledelayed              }{\mathrel}{rule-delayed}%
-\UnicodeMathSymbol{"029F5}{\setminus                 }{\mathbin}{reverse solidus operator}%
+\UnicodeMathSymbol{"02216}{\setminus                 }{\mathbin}{reverse solidus operator}%
 \UnicodeMathSymbol{"029F6}{\dsol                     }{\mathbin}{solidus with overbar}%
 \UnicodeMathSymbol{"029F7}{\rsolbar                  }{\mathbin}{reverse solidus with horizontal stroke}%
 \UnicodeMathSymbol{"029F8}{\xsol                     }{\mathop}{big solidus}%


### PR DESCRIPTION
## Status
**READY**

## Description
STIX Two has been updated. (stipub/stixfonts#179) Therefore, this change
achieves Unicode compliance without producing inconsistencies with
STIX. This is regarding issue #181.

## Todo
- [X] Tests added to cover new/fixed functionality
- [X] Documentation added if necessary
- [X] Code follows expl3 style guidelines

## Minimal example demonstrating the new/fixed functionality
```tex
\documentclass{article}
\usepackage{unicode-math}
\setmathfont{texgyrepagella-math.otf}% filename only please!
\begin{document}
\[
  \setminus, \smallsetminus
\]
\end{document}
```

