### PR TITLE
Fix problems with DocStrip’s “@@” replacement in um-code-opening.dtx

### DIFF
--- a/um-code-opening.dtx
+++ b/um-code-opening.dtx
@@ -281,7 +281,7 @@
 \tl_map_inline:nn
   {
     \new@mathgroup\cdp@list\cdp@elt\DeclareMathSizes
-    \@DeclareMathSizes\newmathalphabet\newmathalphabet@@\newmathalphabet@@@
+    \@DeclareMathSizes\newmathalphabet\newmathalphabet@@@@\newmathalphabet@@@@@
     \DeclareMathVersion\define@mathalphabet\define@mathgroup\addtoversion
     \version@list\version@elt\alpha@list\alpha@elt
     \restore@mathversion\init@restore@version\dorestore@version\process@table


### PR DESCRIPTION
## Status
**READY**

## Description
`\newmathalphabet@@\newmathalphabet@@@` in line 284 of `um-code-opening.dtx` yields `\newmathalphabet__um\newmathalphabet__um@` after interpreting with DocStrip.
It should yield `\newmathalphabet@@\newmathalphabet@@@` (see `ltfsscmp.dtx` of LaTeX 2e kernel)
so a `@@` to `@@@@` replacement is necessary.

By the way, `\newmathalphabet`, `\newmathalphabet@@` and `\newmathalphabet@@@` in LaTeX 2e kernel are reserved only for compatibility with NFSS version 1. Is there necessity of reserving them in `unicode-math`?

## Todo
- [x] Tests added to cover fixed functionality
- [ ] Documentation added if necessary
- [ ] Code follows expl3 style guidelines

## Minimal example demonstrating the fixed functionality
```tex
\documentclass{article}
\usepackage{unicode-math}
\setmathfont{texgyrepagella-math.otf}% filename only please!
\begin{document}
\newmathalphabet{\newmathbf}{cmr}{bx}{n}
\end{document}
```

